### PR TITLE
Fix issues

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,7 +91,14 @@ class ServerlessJestPlugin {
           .then(() => createTest(this.serverless, this.options)),
       'invoke:test:test': () =>
         BbPromise.bind(this)
-          .then(() => runTests(this.serverless, this.options, this.config)),
+          .then(() => runTests(this.serverless, this.options, this.config))
+          .catch((err) => {
+            if (err.success === false) {
+              // This is a successful run but with failed tests
+              process.exit(1);
+            }
+            throw err;
+          }),
       'create:function:create': () =>
         BbPromise.bind(this)
           .then(() => createFunction(this.serverless, this.options))

--- a/lib/run-tests.js
+++ b/lib/run-tests.js
@@ -24,7 +24,13 @@ const runTests = (serverless, options, conf) => new BbPromise((resolve, reject) 
 
   return runCLI({ config },
     serverless.config.servicePath,
-    success => resolve(success));
+    (result) => {
+      if (result.success) {
+        resolve(result);
+      } else {
+        reject(result);
+      }
+    });
 });
 
 module.exports = runTests;

--- a/lib/run-tests.js
+++ b/lib/run-tests.js
@@ -20,9 +20,6 @@ const runTests = (serverless, options, conf) => new BbPromise((resolve, reject) 
     } else {
       return reject(`Function "${functionName}" not found`);
     }
-  } else {
-    const functionsRegex = allFunctions.map(name => `${name}\\.test\\.js$`).join('|');
-    Object.assign(config, { testRegex: functionsRegex });
   }
 
   return runCLI({ config },


### PR DESCRIPTION
This fixes 2 issues in the serverless-jest-plugin

1. As documented in CANDDi IP's __tests__/README.MD, there are some lines of code in run-tests.js we needed to delete to run our unit tests over our shared files.
2. The plugin did not return a non-0 exit code if Jest did, which is crucial for stopping the deploy process if Jest runs into a fail